### PR TITLE
Promos are also limited by available redemptions.

### DIFF
--- a/app/src/main/java/castofo_nower/com/co/nower/controllers/PromoCardAnimator.java
+++ b/app/src/main/java/castofo_nower/com/co/nower/controllers/PromoCardAnimator.java
@@ -354,6 +354,16 @@ GestureDetector.OnGestureListener, AlertDialogsResponses, ParsedErrors {
                      R.string.ok, R.string.go_to_my_promos, OBTAINED_PROMO);
   }
 
+  public void disableNowButtonDueToNoMoreStock() {
+    TextView availableRedemptions =  (TextView) promosFlipper.getCurrentView()
+                                     .findViewById
+                                     (R.id.promo_available_redemptions);
+    availableRedemptions.setText(getResources().getString(R.string.zero));
+    Button nowButton = (Button) promosFlipper.getCurrentView()
+                       .findViewById(R.id.now_button);
+    nowButton.setEnabled(false);
+  }
+
   @Override
   public void notifyUserResponse(String action, int buttonPressedId) {
     switch (action) {
@@ -389,10 +399,13 @@ GestureDetector.OnGestureListener, AlertDialogsResponses, ParsedErrors {
           //TODO cerrar sesión porque se intentó utilizar un usuario inválido.
         }
         else if (errorsMessages.containsKey("promo")) {
+          if (errorsMessages.get("promo")
+              .contains(getResources().getString(R.string.no_more_stock))) {
+            disableNowButtonDueToNoMoreStock();
+          }
           UserFeedback
           .showAlertDialog(this, R.string.never, errorsMessages.get("promo"),
                            R.string.ok, UserFeedback.NO_BUTTON_TO_SHOW, action);
-          //TODO desactivar el botón y poner personas límite en cero.
         }
         break;
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -72,5 +72,7 @@
   <string name="sorry">Lo sentimos</string>
   <string name="error_loading_map">No fue posible cargar el mapa.</string>
   <string name="exit">Salir</string>
+  <string name="no_more_stock">has no more stock</string>
+  <string name="zero">0</string>
 
 </resources>


### PR DESCRIPTION
When the user tries to take a promo, but in that specific moment it was taken by all the available users, a message is displayed to tell him/her that there are no more stock, the now-button is disabled and that promo's availability is reduced to zero (0).